### PR TITLE
Fixing PHP shell arg position

### DIFF
--- a/.larasail/setup
+++ b/.larasail/setup
@@ -14,11 +14,11 @@
 
 PHP="7.4"
 
-if [ "$1" = "php73" ]; then
+if [ "$2" = "php73" ]; then
    PHP="7.3"
-elif [ "$1" = "php72" ]; then
+elif [ "$2" = "php72" ]; then
    PHP="7.2"
-elif [ "$1" = "php71" ]; then
+elif [ "$2" = "php71" ]; then
    PHP="7.1"
 fi
 


### PR DESCRIPTION
- [ ] ♻️ Refactor
- [ ] ✨ Feature
- [X] 🐛 Bug Fix
- [ ] 👷 Optimization
- [ ] 📝 Documentation Update
- [ ] 🚩 Other

## Description

The shell args to the PHP options were looking at the incorrect position.  The result was that no matter what PHP version you passed it, 7.4 got installed.  This restores the functionality that allows for previous versions of PHP. 

## Added to documentation?

- [ ] 📜 readme
- [X] 🙅 no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?
![Oopsie](https://media.giphy.com/media/BsQAVgY6ksvIY/giphy.gif)