### PR TITLE
Www alias patch

### DIFF
--- a/.larasail/host
+++ b/.larasail/host
@@ -137,7 +137,7 @@ else
 	echo "New Virtual Host Created"
 fi
 
-if [! echo "127.0.0.1	$domain" >> /etc/hosts
+if ! echo "127.0.0.1	$domain" >> /etc/hosts
 then
 	echo "ERROR: Not able write in /etc/hosts"
 	exit;

--- a/.larasail/host
+++ b/.larasail/host
@@ -156,7 +156,7 @@ echo "[yes/no]"
 read letsencrypt
 
 if [ "$letsencrypt" = "yes" ]; then
-	sudo certbot --nginx {$certbotDomains}
+	sudo certbot --nginx ${certbotDomains}
 fi
 
 exit;

--- a/.larasail/host
+++ b/.larasail/host
@@ -33,6 +33,7 @@ fi
 phpVersion="$(php -v | head -n 1 | cut -d " " -f 2 | cut -c 1,2,3)"
 domain=$1
 rootPath=$2
+withWwwAlias=$3
 sitesEnable='/etc/nginx/sites-enabled/'
 sitesAvailable='/etc/nginx/sites-available/'
 serverRoot='/var/www/'
@@ -90,6 +91,13 @@ if ! [ -d $sitesAvailable ]; then
 fi
 
 configName=$domain
+serverName=$domain
+certbotDomains="-d ${domain}"
+
+if [ "$withWwwAlias" = "--www-alias" ]; then
+        serverName="$domain www.$domain"
+	certbotDomains="-d ${domain} -d www.${domain}"
+fi
 
 if ! echo "server {
 
@@ -97,7 +105,7 @@ if ! echo "server {
 
         index index.php index.html index.htm;
 
-        server_name $domain www.$domain;
+        server_name $serverName;
 
         location / {
                 try_files \$uri \$uri/ /index.php?\$query_string;
@@ -129,7 +137,7 @@ else
 	echo "New Virtual Host Created"
 fi
 
-if ! echo "127.0.0.1	$domain" >> /etc/hosts
+if [! echo "127.0.0.1	$domain" >> /etc/hosts
 then
 	echo "ERROR: Not able write in /etc/hosts"
 	exit;
@@ -148,7 +156,7 @@ echo "[yes/no]"
 read letsencrypt
 
 if [ "$letsencrypt" = "yes" ]; then
-	sudo certbot --nginx -d ${domain} -d www.${domain}
+	sudo certbot --nginx {$certbotDomains}
 fi
 
 exit;

--- a/.larasail/new
+++ b/.larasail/new
@@ -15,7 +15,7 @@
 shift
 
 if [ -z $1 ]; then
-    echo "Usage: larasail new <project-name> [--jet <livewire|inertia>] [--teams]"
+    echo "Usage: larasail new <project-name> [--jet <livewire|inertia>] [--teams] [--www-alias]"
     echo ""
     echo "${Cyan}Tip: you can use periods in project name to automatically create a host for it"
     exit
@@ -32,6 +32,7 @@ shift
 
 INSTALL_JET=false
 JET_WITH_TEAMS=false
+HOST_WITH_WWW_ALIAS=false
 
 while [ $# -gt 0 ]; do
     case $1 in
@@ -54,6 +55,9 @@ while [ $# -gt 0 ]; do
         --teams)
             JET_WITH_TEAMS=true
             ;;
+        --www-alias)
+            HOST_WITH_WWW_ALIAS=true
+            ;;
     esac
     shift
 done
@@ -62,7 +66,12 @@ composer create-project --prefer-dist laravel/laravel "$PROJECT_PATH"
 
 if [ -n $HOST ]; then
     echo "Setting up host '$HOST'..."
-    sudo bash /etc/.larasail/host "$HOST" "$PROJECT_PATH"
+    
+    if $HOST_WITH_WWW_ALIAS; then
+        sudo bash /etc/.larasail/host "$HOST" "$PROJECT_PATH" --www-alias
+    else
+        sudo bash /etc/.larasail/host "$HOST" "$PROJECT_PATH"
+    fi
 fi
 
 if $INSTALL_JET; then

--- a/README.md
+++ b/README.md
@@ -48,10 +48,11 @@ larasail setup php80 # Install with PHP 8.0
 After setting up the server you can create a new project automatically by running:
 
 ```
-larasail new <project-name> [--jet <livewire|inertia>] [--teams]
+larasail new <project-name> [--jet <livewire|inertia>] [--teams] [--www-alias]
 ```
 
 This will automatically create a project folder in `/var/www` and set up a host if provided project name contains periods (they will be replaced with underscores for the directory name).
+By default, larasail sets up the Nginx site configuration and Letsencrypt SSL certificate for your domain. If you would like both the `www` alias and root domain setup (i.e `example.com` and `www.example.com`) kindly pass the `--www-alias` flag.
 
 ### :construction: Manually
 
@@ -70,15 +71,17 @@ cd /var/www && laravel new mywebsite --jet
 Then, you'll need to setup a new Nginx Host by running:
 
 ```
-larasail host mywebsite.com /var/www/mywebsite
+larasail host mywebsite.com /var/www/mywebsite --www-alias
 ```
 
-`larasail host` accepts 2 parameters:
+`larasail host` accepts 3 parameters:
 
-1. Your website domain *(website.com)*
-2. The location of the files for your site *(/var/www/website/public)*
+1. Your website domain *(mywebsite.com)*
+2. The location of the files for your site *(/var/www/mywebsite/public)*
+3. Optional flag if you would like to include your project's `www` alias: `www.mywebsite.com` *(--www-alias)*
 
 Finally, point your Domain to the IP address of your new server... And Wallah, you're ready to rock 🤘 with your new Laravel website.
+If you used the `--www-alias` flag, don't forget to add your domain's www `CNAME` record
 
 ## Passwords
 


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the LaraSail Contributing Guide: https://github.com/thedevdojo/larasail/blob/HEAD/CONTRIBUTING.md#creating-a-pull-request.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] ♻️ Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 👷 Optimization
- [ ] 📝 Documentation Update
- [ ] 🚩 Other

## Description
Fix #57. Adds a --www-alias flag to `host` and `new` if the user wants to setup the `www` alias of the domain. By default, only the domain is setup

## Related Tickets & Documents
#57 


## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
N/A


## Added to documentation?

- [x] 📜 readme
- [ ] 🙅 no documentation needed
