### PR TITLE
Mariadb support

### DIFF
--- a/.larasail/setup
+++ b/.larasail/setup
@@ -68,6 +68,10 @@ echo "mysql-server mysql-server/root_password_again password $MYSQLPASS" | sudo 
 echo "mysql-server-5.7 mysql-server/root_password password $MYSQLPASS" | sudo debconf-set-selections
 echo "mysql-server-5.7 mysql-server/root_password_again password $MYSQLPASS" | sudo debconf-set-selections
 
+echo "mysql-community-server mysql-community-server/root-pass password ${MYSQLPASS}" | sudo debconf-set-selections
+echo "mysql-community-server mysql-community-server/re-root-pass password ${MYSQLPASS}" | sudo debconf-set-selections
+echo "mysql-community-server mysql-server/default-auth-override select Use Legacy Authentication Method (Retain MySQL 5.x Compatibility)" | sudo debconf-set-selections
+
 sudo apt-get install -y ${MYSQL_PACKAGE}
 
 # Get current client IP address

--- a/.larasail/setup
+++ b/.larasail/setup
@@ -67,11 +67,13 @@ echo "mysql-server-5.7 mysql-server/root_password password $MYSQLPASS" | sudo de
 echo "mysql-server-5.7 mysql-server/root_password_again password $MYSQLPASS" | sudo debconf-set-selections
 echo "mysql-server mysql-server/root-pass password ${MYSQLPASS}"|sudo debconf-set-selections
 echo "mysql-server mysql-server/re-root-pass password ${MYSQLPASS}"|sudo debconf-set-selections
+echo "mysql-server-8.0 mysql-server/root-pass password ${MYSQLPASS}"|sudo debconf-set-selections
+echo "mysql-server-8.0 mysql-server/re-root-pass password ${MYSQLPASS}"|sudo debconf-set-selections
 
 
 if [ "$2" = "mariadb" ] || [ "$3" = "mariadb" ]; then
-   echo "mariadb-server mysql-server/root-pass password ${MYSQLPASS}"|sudo debconf-set-selections
-   echo "mariadb-server mysql-server/re-root-pass password ${MYSQLPASS}"|sudo debconf-set-selections
+   echo "mariadb-server-10.3 mysql-server/root-pass password ${MYSQLPASS}"|sudo debconf-set-selections
+   echo "mariadb-server-10.3 mysql-server/re-root-pass password ${MYSQLPASS}"|sudo debconf-set-selections
 fi
 
 sudo apt-get install -y ${MYSQL_PACKAGE}

--- a/.larasail/setup
+++ b/.larasail/setup
@@ -63,16 +63,15 @@ echo 'password='${MYSQLPASS} >> /home/larasail/.my.cnf
 chmod 600 /home/larasail/.my.cnf
 
 export DEBIAN_FRONTEND=noninteractive
-echo "mysql-server mysql-server/root_password password $MYSQLPASS" | sudo debconf-set-selections
-echo "mysql-server mysql-server/root_password_again password $MYSQLPASS" | sudo debconf-set-selections
 echo "mysql-server-5.7 mysql-server/root_password password $MYSQLPASS" | sudo debconf-set-selections
 echo "mysql-server-5.7 mysql-server/root_password_again password $MYSQLPASS" | sudo debconf-set-selections
+echo "mysql-server mysql-server/root-pass password ${MYSQLPASS}"|sudo debconf-set-selections
+echo "mysql-server mysql-server/re-root-pass password ${MYSQLPASS}"|sudo debconf-set-selections
 
 
 if [ "$2" = "mariadb" ] || [ "$3" = "mariadb" ]; then
-   echo "mariadb-server mysql-server/root-pass password ${MYSQLPASS}" | sudo debconf-set-selections
-   echo "mariadb-server mysql-server/re-root-pass password ${MYSQLPASS}" | sudo debconf-set-selections
-   echo "mariadb-server mysql-server/default-auth-override select Use Legacy Authentication Method (Retain MySQL 5.x Compatibility)" | sudo debconf-set-selections
+   echo "mariadb-server mysql-server/root-pass password ${MYSQLPASS}"|sudo debconf-set-selections
+   echo "mariadb-server mysql-server/re-root-pass password ${MYSQLPASS}"|sudo debconf-set-selections
 fi
 
 sudo apt-get install -y ${MYSQL_PACKAGE}

--- a/.larasail/setup
+++ b/.larasail/setup
@@ -26,6 +26,11 @@ elif [ "$2" = "php71" ] || [ "$3" = "php71" ]; then
    PHP="7.1"
 fi
 
+if [ "$2" = "mariadb" ] || [ "$3" = "mariadb" ]; then
+   MYSQL_SERVICE="MariaDB"
+   MYSQL_PACKAGE="mariadb-server"
+fi
+
 setsail
 
 
@@ -65,9 +70,6 @@ echo "mysql-server-5.7 mysql-server/root_password_again password $MYSQLPASS" | s
 
 
 if [ "$2" = "mariadb" ] || [ "$3" = "mariadb" ]; then
-   MYSQL_SERVICE="MariaDB"
-   MYSQL_PACKAGE="mariadb-server"
-   
    echo "mariadb-server mysql-server/root-pass password ${MYSQLPASS}" | sudo debconf-set-selections
    echo "mariadb-server mysql-server/re-root-pass password ${MYSQLPASS}" | sudo debconf-set-selections
    echo "mariadb-server mysql-server/default-auth-override select Use Legacy Authentication Method (Retain MySQL 5.x Compatibility)" | sudo debconf-set-selections

--- a/.larasail/setup
+++ b/.larasail/setup
@@ -26,11 +26,6 @@ elif [ "$2" = "php71" ] || [ "$3" = "php71" ]; then
    PHP="7.1"
 fi
 
-if [ "$2" = "mariadb" ] || [ "$3" = "mariadb" ]; then
-   MYSQL_SERVICE="MariaDB"
-   MYSQL_PACKAGE="mariadb-server"
-fi
-
 setsail
 
 
@@ -62,15 +57,21 @@ echo 'password='${MYSQLPASS} >> /home/larasail/.my.cnf
 
 chmod 600 /home/larasail/.my.cnf
 
-
+export DEBIAN_FRONTEND=noninteractive
 echo "mysql-server mysql-server/root_password password $MYSQLPASS" | sudo debconf-set-selections
 echo "mysql-server mysql-server/root_password_again password $MYSQLPASS" | sudo debconf-set-selections
 echo "mysql-server-5.7 mysql-server/root_password password $MYSQLPASS" | sudo debconf-set-selections
 echo "mysql-server-5.7 mysql-server/root_password_again password $MYSQLPASS" | sudo debconf-set-selections
 
-echo "mysql-community-server mysql-community-server/root-pass password ${MYSQLPASS}" | sudo debconf-set-selections
-echo "mysql-community-server mysql-community-server/re-root-pass password ${MYSQLPASS}" | sudo debconf-set-selections
-echo "mysql-community-server mysql-server/default-auth-override select Use Legacy Authentication Method (Retain MySQL 5.x Compatibility)" | sudo debconf-set-selections
+
+if [ "$2" = "mariadb" ] || [ "$3" = "mariadb" ]; then
+   MYSQL_SERVICE="MariaDB"
+   MYSQL_PACKAGE="mariadb-server"
+   
+   echo "mariadb-server mysql-server/root-pass password ${MYSQLPASS}" | sudo debconf-set-selections
+   echo "mariadb-server mysql-server/re-root-pass password ${MYSQLPASS}" | sudo debconf-set-selections
+   echo "mariadb-server mysql-server/default-auth-override select Use Legacy Authentication Method (Retain MySQL 5.x Compatibility)" | sudo debconf-set-selections
+fi
 
 sudo apt-get install -y ${MYSQL_PACKAGE}
 

--- a/.larasail/setup
+++ b/.larasail/setup
@@ -13,15 +13,22 @@
 . /etc/.larasail/includes/format
 
 PHP="7.4"
+MYSQL_SERVICE="MySQL"
+MYSQL_PACKAGE="mysql-server"
 
-if [ "$2" = "php80" ]; then
+if [ "$2" = "php80" ] || [ "$3" = "php80" ]; then
    PHP="8.0"
-elif [ "$2" = "php73" ]; then
+elif [ "$2" = "php73" ] || [ "$3" = "php73" ]; then
    PHP="7.3"
-elif [ "$2" = "php72" ]; then
+elif [ "$2" = "php72" ] || [ "$3" = "php72" ]; then
    PHP="7.2"
-elif [ "$2" = "php71" ]; then
+elif [ "$2" = "php71" ] || [ "$3" = "php71" ]; then
    PHP="7.1"
+fi
+
+if [ "$2" = "mariadb" ] || [ "$3" = "mariadb" ]; then
+   MYSQL_SERVICE="MariaDB"
+   MYSQL_PACKAGE="mariadb-server"
 fi
 
 setsail
@@ -38,7 +45,7 @@ sudo ufw allow 'Nginx HTTPS'
 sudo systemctl restart nginx
 
 bar
-cyan "| Installing MySQL ";
+cyan "| Installing $MYSQL_SERVICE ";
 bar
 
 MYSQLPASS=$(openssl rand -base64 32)
@@ -61,7 +68,7 @@ echo "mysql-server mysql-server/root_password_again password $MYSQLPASS" | sudo 
 echo "mysql-server-5.7 mysql-server/root_password password $MYSQLPASS" | sudo debconf-set-selections
 echo "mysql-server-5.7 mysql-server/root_password_again password $MYSQLPASS" | sudo debconf-set-selections
 
-sudo apt-get install -y mysql-server
+sudo apt-get install -y ${MYSQL_PACKAGE}
 
 # Get current client IP address
 CLIENT_IP=$(echo $SSH_CLIENT | awk '{ print $1}')

--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ larasail setup php72 # Install with PHP 7.2
 larasail setup php73 # Install with PHP 7.3
 larasail setup php80 # Install with PHP 8.0
 ```
+### Database
+
+By default, larasail will setup the latest version of MySQL. To opt for MariaDB instead, kindly pass `mariadb` to `larasail setup` as the second or third parameter like so:
+
+```
+larasail setup mariadb # will install default php version (7.4) and MariaDB
+larasail setup php80 mariadb # will install the selected php version (8.0 in this case) and MariaDB
+larasail setup mariadb php80 # same as 2 above
+
+```
 
 ## Creating a New Site
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] ♻️ Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 👷 Optimization
- [ ] 📝 Documentation Update
- [ ] 🚩 Other

## Description

Allows a user to opt for MariaDB in place of mysql.

To setup, a user may setup using either formats:
```

1. $ larasail setup mariadb # will install default php version (7.4) and MariaDB
2. $ larasail setup php80 mariadb # will install the selected php version (8.0 in this case) and MariaDB
3. $ larasail setup mariadb php80 # same as 2 above

```

## Related Tickets & Documents

#60 

## Added to documentation?

- [x] 📜 readme
- [ ] 🙅 no documentation needed