### PR TITLE
Fix MariaDB Access Denied #67

### DIFF
--- a/.larasail/setup
+++ b/.larasail/setup
@@ -49,6 +49,7 @@ cyan "| Installing $MYSQL_SERVICE ";
 bar
 
 MYSQLPASS=$(openssl rand -base64 32)
+MYSQLUSER='larasail_admin'
 
 sudo apt-get update
 if [ ! -d /etc/.larasail/tmp ]; then
@@ -57,8 +58,8 @@ fi
 
 
 echo '[client]' > /home/larasail/.my.cnf
-echo 'user=root' >> /home/larasail/.my.cnf
-echo 'password='${MYSQLPASS} >> /home/larasail/.my.cnf
+echo "user=${MYSQLUSER}" >> /home/larasail/.my.cnf
+echo "password='${MYSQLPASS}" >> /home/larasail/.my.cnf
 
 chmod 600 /home/larasail/.my.cnf
 
@@ -77,6 +78,9 @@ if [ "$2" = "mariadb" ] || [ "$3" = "mariadb" ]; then
 fi
 
 sudo apt-get install -y ${MYSQL_PACKAGE}
+
+sudo service mysql start
+sudo mysql -uroot -p${MYSQLPASS} -e "CREATE USER ${MYSQLUSER}@localhost IDENTIFIED BY '${MYSQLPASS}'; GRANT ALL PRIVILEGES ON *.* TO ${MYSQLUSER}@localhost WITH GRANT OPTION;"
 
 # Get current client IP address
 CLIENT_IP=$(echo $SSH_CLIENT | awk '{ print $1}')

--- a/.larasail/setup
+++ b/.larasail/setup
@@ -59,7 +59,7 @@ fi
 
 echo '[client]' > /home/larasail/.my.cnf
 echo "user=${MYSQLUSER}" >> /home/larasail/.my.cnf
-echo "password='${MYSQLPASS}" >> /home/larasail/.my.cnf
+echo "password='${MYSQLPASS}'" >> /home/larasail/.my.cnf
 
 chmod 600 /home/larasail/.my.cnf
 

--- a/.larasail/setup
+++ b/.larasail/setup
@@ -49,7 +49,7 @@ cyan "| Installing $MYSQL_SERVICE ";
 bar
 
 MYSQLPASS=$(openssl rand -base64 32)
-MYSQLUSER='larasail_admin'
+MYSQLUSER='dbadmin'
 
 sudo apt-get update
 if [ ! -d /etc/.larasail/tmp ]; then


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] ♻️ Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 👷 Optimization
- [ ] 📝 Documentation Update
- [ ] 🚩 Other

## Description

By default, MariaDB uses `unix_socket` plugin for `root`. This restricts `root` user db access to the root user and users with `sudo` access. Opinion is divided among sysadmin on this and have elected to leave the default behavior intact for the end users.

This PR fixes this by creating a `dbadmin` user for larasail user's exclusive use. I should have named this user `larasail` but realized that `larasail database init` suggests the same user which may cause issues for a small subset of users

## Related Tickets & Documents

#67

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

N/A

## Added to documentation?

- [ ] 📜 readme
- [x] 🙅 no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?
