### PR TITLE
Pass ---www-alias to host command

### DIFF
--- a/.larasail/larasail
+++ b/.larasail/larasail
@@ -13,7 +13,7 @@ if [ "$1" = "-h" ] || [ -z $1 ]
 then
     . /etc/.larasail/includes/help
 elif [ "$1" = "host" ] ; then
-	sudo sh /etc/.larasail/$1 $2 $3
+	sudo sh /etc/.larasail/$1 $2 $3 $4
 else
     . /etc/.larasail/$1 $2 $3
 fi


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] ♻️ Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 👷 Optimization
- [ ] 📝 Documentation Update
- [ ] 🚩 Other

## Description

When running `larasail host site.example.com /var/www/site --www-alias`, the `www-alias` parameter does not get passed to `/etc/.larasail/host` bash script

## Related Tickets & Documents

#85 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

Not applicable

## Added to documentation?

- [ ] 📜 readme
- [x] 🙅 no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?
