### PR TITLE
Remove ufw allow for 3306 for security

### DIFF
--- a/.larasail/setup
+++ b/.larasail/setup
@@ -108,8 +108,8 @@ sudo mysql -uroot -p${MYSQLPASS} -e "CREATE USER ${MYSQLUSER}@localhost IDENTIFI
 # Get current client IP address
 CLIENT_IP=$(echo $SSH_CLIENT | awk '{ print $1}')
 
-# Enable 3306 ports in order to connect to database via Sequel Pro
-sudo ufw allow from ${CLIENT_IP}/32 to any port 3306
+# To enable 3306 ports in order to connect to database via Sequel Pro, run:
+# sudo ufw allow from ${CLIENT_IP}/32 to any port 3306
 
 
 bar


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the LaraSail Contributing Guide: https://github.com/thedevdojo/larasail/blob/HEAD/CONTRIBUTING.md#creating-a-pull-request.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] ♻️ Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 👷 Optimization
- [ ] 📝 Documentation Update
- [ ] 🚩 Other

## Description

Disabling the ufw allow rule for the client IP for port 3306 for security reasons.

If you still need this enabled, you can manually do it with:

```
sudo ufw allow from ${CLIENT_IP}/32 to any port 3306
```

## Related Tickets & Documents

N/A

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

N/a

## Added to documentation?

- [ ] 📜 readme
- [x] 🙅 no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?
